### PR TITLE
Add CircleCI setup instructions for Codespaces

### DIFF
--- a/circle_ci/readme.md
+++ b/circle_ci/readme.md
@@ -35,8 +35,6 @@ These steps **must** be completed prior to starting other labs.
 
   - If `gh valet version` did not produce similar output then please follow the troubleshooting [guide](#troubleshoot-the-valet-cli).
 
-
-
 ## Labs for CircleCI
 
 Perform the following labs to test-drive Valet


### PR DESCRIPTION
## What is changing?
This adds the base setup instructions for creating the codespace for use in the CircleCI labs.  There is no bootstrapping instructions or scripts because they are not needed.  The CircleCI labs will be using a common GitHub Organization with public repos for the pipelines and builds.  I have create a temporary one for getting up and running creating the labs [here](https://github.com/orgs/labs-data/repositories).  The only requirement on CircleCI side for the user is a API token, which will be addressed in the configure lab.    

closes github/valet#4564
closes github/valet#4562