### PR TITLE
Travis: configure

### DIFF
--- a/travis/1-configure.md
+++ b/travis/1-configure.md
@@ -20,7 +20,7 @@ You will need to complete all of the setup instructions [here](./readme.md#confi
     - Open Travis CI in a new browser tab.
     - Click on your profile icon in the top right hand corner to reveal a dropdown menu.
     - Click on the 'Settings' tab.
-    - Click on the 'COPY TOKEN' button under the API authentication header and save in a safe location.
+    - Click on the 'COPY TOKEN' button under "API authentication header" and save in a safe location.
 
 2. Run the `configure` CLI command:
     - Select the `TERMINAL` tab from within the codespace terminal window.


### PR DESCRIPTION
Depends on [this](https://github.com/valet-customers/labs/pull/46) PR. 

Travis does not have documentation how to fetch the Travis API token via its GUI (only via the command line) so I added some more details on how to do it vs being able to link docs. 