### PR TITLE
🐛  GitLab: Docker host error

### DIFF
--- a/gitlab/1-configure.md
+++ b/gitlab/1-configure.md
@@ -8,7 +8,7 @@ You will need to complete all of the setup instructions [here](./readme.md#confi
 
 1. Run the setup script in the codespace terminal to ensure the GitLab server is ready:
     ```bash
-    source ./gitlab/bootstrap/setup.sh
+    ./gitlab/bootstrap/setup.sh
     ```
 
 2. Open the GitLab server in a new browser tab:


### PR DESCRIPTION
This adds `source` back to the GitLab setup script command, so that the first time a user runs it the `DOCKER_ARGS` env to set the network to local host is set in the current terminal session.   Without `source` the GitLab server is not available on localhost, unless a new terminal session is created