### PR TITLE
Gitlab review

### DIFF
--- a/azure_devops/5-custom-transformers.md
+++ b/azure_devops/5-custom-transformers.md
@@ -149,7 +149,7 @@ Open the workflow that is generated and inspect the contents. Now the `DotnetCor
 
 You can also use custom transformers to edit the values of environment variables in converted workflows. In this example, you will be updating the `BUILDCONFIGURATION` environment variable to be `Debug` instead of `Release`.
 
-To do this, add the following code to the `transformers.rb` file.
+To do this, add the following code at the top of the `transformers.rb` file.
 
 ```ruby
 env "BUILDCONFIGURATION", "Debug"

--- a/gitlab/5-custom-transformers.md
+++ b/gitlab/5-custom-transformers.md
@@ -119,7 +119,7 @@ end
 
 You can also use custom transformers to edit the values of environment variables in converted workflows. In this example, you will update the `PLAN_JSON` environment variable to be `custom_plan.json` instead of `plan.json`.
 
-To do this, add the following code to the `transformers.rb` file.
+To do this, add the following code at the top of the `transformers.rb` file.
 
 ```ruby
 env "PLAN_JSON", "custom_plan.json"

--- a/jenkins/5-custom-transformers.md
+++ b/jenkins/5-custom-transformers.md
@@ -205,7 +205,7 @@ Now you can perform another `dry-run` command with the `--custom-transformers` C
 
 You can also use custom transformers to edit the values of environment variables in converted workflows. In this example, you will be updating the `DB_ENGINE` environment variable to be `mongodb` instead of `sqlite`.
 
-To do this, add the following code to the `transformers.rb` file.
+To do this, add the following code at the top of the `transformers.rb` file.
 
 ```ruby
 env "DB_ENGINE", "mongodb"


### PR DESCRIPTION
A couple of small items I found while reviewing the GitLab lab:

- Use the `tmp/dry-run` directory rather than `tmp` in the custom transformer section for consistency
- Clarify verbiage re: where to put `env` in the `transformers.rb` file across all labs