### PR TITLE
Update `audit` and `dry-run` example paths

### DIFF
--- a/azure_devops/2-audit.md
+++ b/azure_devops/2-audit.md
@@ -149,21 +149,23 @@ The final section of the audit report provides a manifest of all of the files th
 ```md
 ### Successful
 
-#### valet-bootstrap/valet-classic-test-import1
+#### valet-bootstrap/pipelines/valet-pipeline2
 
-- [valet-bootstrap/valet-classic-test-import1.yml](valet-bootstrap/valet-classic-test-import1.yml)
-- [valet-bootstrap/valet-classic-test-import1.config.json](valet-bootstrap/valet-classic-test-import1.config.json)
-
-#### valet-bootstrap/valet-classic-test-import2
-
-- [valet-bootstrap/valet-classic-test-import2.yml](valet-bootstrap/valet-classic-test-import2.yml)
-- [valet-bootstrap/valet-classic-test-import2.config.json](valet-bootstrap/valet-classic-test-import2.config.json)
+- [pipelines/valet-bootstrap/pipelines/valet-pipeline2/.github/workflows/valet-pipeline2.yml](pipelines/valet-bootstrap/pipelines/valet-pipeline2/.github/workflows/valet-pipeline2.yml)
+- [pipelines/valet-bootstrap/pipelines/valet-pipeline2/config.json](pipelines/valet-bootstrap/pipelines/valet-pipeline2/config.json)
+- [pipelines/valet-bootstrap/pipelines/valet-pipeline2/source.yml](pipelines/valet-bootstrap/pipelines/valet-pipeline2/source.yml)
 
 #### valet-bootstrap/pipelines/valet-pipeline1
 
-- [valet-bootstrap/pipelines/valet-pipeline1.yml](valet-bootstrap/pipelines/valet-pipeline1.yml)
-- [valet-bootstrap/pipelines/valet-pipeline1.config.json](valet-bootstrap/pipelines/valet-pipeline1.config.json)
-- [valet-bootstrap/pipelines/valet-pipeline1.source.yml](valet-bootstrap/pipelines/valet-pipeline1.source.yml)
+- [pipelines/valet-bootstrap/pipelines/valet-pipeline1/.github/workflows/valet-pipeline1.yml](pipelines/valet-bootstrap/pipelines/valet-pipeline1/.github/workflows/valet-pipeline1.yml)
+- [pipelines/valet-bootstrap/pipelines/valet-pipeline1/config.json](pipelines/valet-bootstrap/pipelines/valet-pipeline1/config.json)
+- [pipelines/valet-bootstrap/pipelines/valet-pipeline1/source.yml](pipelines/valet-bootstrap/pipelines/valet-pipeline1/source.yml)
+
+#### valet-bootstrap/pipelines/valet-custom-transformer-example
+
+- [pipelines/valet-bootstrap/pipelines/valet-custom-transformer-example/.github/workflows/valet-custom-transformer-example.yml](pipelines/valet-bootstrap/pipelines/valet-custom-transformer-example/.github/workflows/valet-custom-transformer-example.yml)
+- [pipelines/valet-bootstrap/pipelines/valet-custom-transformer-example/config.json](pipelines/valet-bootstrap/pipelines/valet-custom-transformer-example/config.json)
+- [pipelines/valet-bootstrap/pipelines/valet-custom-transformer-example/source.yml](pipelines/valet-bootstrap/pipelines/valet-custom-transformer-example/source.yml)
 ```
 
 Each pipeline will have a variety of files written that include:
@@ -180,17 +182,17 @@ Each pipeline will have a variety of files written that include:
   
     ```csv
     Pipeline,Action,File path
-    lab-test/pipelines/valet-pipeline2,actions/checkout@v2,/data/tmp/adoa/lab-test/pipelines/valet-pipeline2.yml
-    lab-test/pipelines/valet-pipeline1,actions/checkout@v2,/data/tmp/adoa/lab-test/pipelines/valet-pipeline1.yml
-    lab-test/pipelines/valet-custom-transformer-example,actions/checkout@v2,/data/tmp/adoa/lab-test/pipelines/valet-custom-transformer-example.yml
-    lab-test/pipelines/valet-custom-transformer-example,actions/setup-node@v2,/data/tmp/adoa/lab-test/pipelines/valet-custom-transformer-example.yml
+    valet-bootstrap/pipelines/valet-pipeline2,actions/checkout@v2,/data/tmp/adoa/valet-bootstrap/pipelines/valet-pipeline2.yml
+    valet-bootstrap/pipelines/valet-pipeline1,actions/checkout@v2,/data/tmp/adoa/valet-bootstrap/pipelines/valet-pipeline1.yml
+    valet-bootstrap/pipelines/valet-custom-transformer-example,actions/checkout@v2,/data/tmp/valet-bootstrap/pipelines/valet-custom-transformer-example.yml
+    valet-bootstrap/pipelines/valet-custom-transformer-example,actions/setup-node@v2,/data/tmp/adoa/valet-bootstrap/pipelines/valet-custom-transformer-example.yml
 
     Pipeline,Secret,File path
 
 
     Pipeline,Runner,File path
-    lab-test/pipelines/valet-pipeline2,mechamachine,/data/tmp/adoa/lab-test/pipelines/valet-pipeline2.yml
-    lab-test/pipelines/valet-custom-transformer-example,mechamachine,/data/tmp/adoa/lab-test/pipelines/valet-custom-transformer-example.yml
+    valet-bootstrap/pipelines/valet-pipeline2,mechamachine,/data/tmp/adoa/valet-bootstrap/pipelines/valet-pipeline2.yml
+    valet-bootstrap/pipelines/valet-custom-transformer-example,mechamachine,/data/tmp/adoa/valet-bootstrap/pipelines/valet-custom-transformer-example.yml
     ```
 
 The contents of this file can be useful in answering questions similar to the following:

--- a/azure_devops/2-audit.md
+++ b/azure_devops/2-audit.md
@@ -182,17 +182,17 @@ Each pipeline will have a variety of files written that include:
   
     ```csv
     Pipeline,Action,File path
-    valet-bootstrap/pipelines/valet-pipeline2,actions/checkout@v2,tmp/adoa/valet-bootstrap/pipelines/valet-pipeline2.yml
-    valet-bootstrap/pipelines/valet-pipeline1,actions/checkout@v2,tmp/adoa/valet-bootstrap/pipelines/valet-pipeline1.yml
-    valet-bootstrap/pipelines/valet-custom-transformer-example,actions/checkout@v2,tmp/valet-bootstrap/pipelines/valet-custom-transformer-example.yml
-    valet-bootstrap/pipelines/valet-custom-transformer-example,actions/setup-node@v2,tmp/adoa/valet-bootstrap/pipelines/valet-custom-transformer-example.yml
+    valet-bootstrap/pipelines/valet-pipeline2,actions/checkout@v2,tmp/audit/pipelines/valet-bootstrap/pipelines/valet-pipeline2/.github/workflows/valet-pipeline2.yml
+    valet-bootstrap/pipelines/valet-pipeline1,actions/checkout@v2,tmp/audit/pipelines/valet-bootstrap/pipelines/valet-pipeline1/.github/workflows/valet-pipeline1.yml
+    valet-bootstrap/pipelines/valet-custom-transformer-example,actions/checkout@v2,tmp/audit/pipelines/valet-bootstrap/pipelines/valet-custom-transformer-example/.github/workflows/valet-custom-transformer-example.yml
+    valet-bootstrap/pipelines/valet-custom-transformer-example,actions/setup-node@v2,tmp/audit/pipelines/valet-bootstrap/pipelines/valet-custom-transformer-example/.github/workflows/valet-custom-transformer-example.yml
 
     Pipeline,Secret,File path
 
 
     Pipeline,Runner,File path
-    valet-bootstrap/pipelines/valet-pipeline2,mechamachine,tmp/adoa/valet-bootstrap/pipelines/valet-pipeline2.yml
-    valet-bootstrap/pipelines/valet-custom-transformer-example,mechamachine,tmp/adoa/valet-bootstrap/pipelines/valet-custom-transformer-example.yml
+    valet-bootstrap/pipelines/valet-pipeline2,mechamachine,tmp/audit/pipelines/valet-bootstrap/pipelines/valet-pipeline2/.github/workflows/valet-pipeline2.yml
+    valet-bootstrap/pipelines/valet-custom-transformer-example,mechamachine,tmp/audit/pipelines/valet-bootstrap/pipelines/valet-custom-transformer-example/.github/workflows/valet-custom-transformer-example.yml
     ```
 
 The contents of this file can be useful in answering questions similar to the following:

--- a/azure_devops/2-audit.md
+++ b/azure_devops/2-audit.md
@@ -182,17 +182,17 @@ Each pipeline will have a variety of files written that include:
   
     ```csv
     Pipeline,Action,File path
-    valet-bootstrap/pipelines/valet-pipeline2,actions/checkout@v2,/data/tmp/adoa/valet-bootstrap/pipelines/valet-pipeline2.yml
-    valet-bootstrap/pipelines/valet-pipeline1,actions/checkout@v2,/data/tmp/adoa/valet-bootstrap/pipelines/valet-pipeline1.yml
-    valet-bootstrap/pipelines/valet-custom-transformer-example,actions/checkout@v2,/data/tmp/valet-bootstrap/pipelines/valet-custom-transformer-example.yml
-    valet-bootstrap/pipelines/valet-custom-transformer-example,actions/setup-node@v2,/data/tmp/adoa/valet-bootstrap/pipelines/valet-custom-transformer-example.yml
+    valet-bootstrap/pipelines/valet-pipeline2,actions/checkout@v2,tmp/adoa/valet-bootstrap/pipelines/valet-pipeline2.yml
+    valet-bootstrap/pipelines/valet-pipeline1,actions/checkout@v2,tmp/adoa/valet-bootstrap/pipelines/valet-pipeline1.yml
+    valet-bootstrap/pipelines/valet-custom-transformer-example,actions/checkout@v2,tmp/valet-bootstrap/pipelines/valet-custom-transformer-example.yml
+    valet-bootstrap/pipelines/valet-custom-transformer-example,actions/setup-node@v2,tmp/adoa/valet-bootstrap/pipelines/valet-custom-transformer-example.yml
 
     Pipeline,Secret,File path
 
 
     Pipeline,Runner,File path
-    valet-bootstrap/pipelines/valet-pipeline2,mechamachine,/data/tmp/adoa/valet-bootstrap/pipelines/valet-pipeline2.yml
-    valet-bootstrap/pipelines/valet-custom-transformer-example,mechamachine,/data/tmp/adoa/valet-bootstrap/pipelines/valet-custom-transformer-example.yml
+    valet-bootstrap/pipelines/valet-pipeline2,mechamachine,tmp/adoa/valet-bootstrap/pipelines/valet-pipeline2.yml
+    valet-bootstrap/pipelines/valet-custom-transformer-example,mechamachine,tmp/adoa/valet-bootstrap/pipelines/valet-custom-transformer-example.yml
     ```
 
 The contents of this file can be useful in answering questions similar to the following:

--- a/azure_devops/4-dry-run.md
+++ b/azure_devops/4-dry-run.md
@@ -32,7 +32,7 @@ You will perform a dry run for a pipeline in the bootstrapped Azure DevOps proje
 
 3. The command will list all the files written to disk when the command succeeds.
 4. View the converted workflow:
-    - Find `tmp/dry-run` in the file explorer pane in your codespace.
+    - Find `tmp/dry-run/pipelines/lab-testing/pipelines/valet-pipeline1/.github/workflows` in the file explorer pane in your codespace.
     - Click `valet-pipeline1.yml` to open.
 
 ## Inspect the output files

--- a/azure_devops/5-custom-transformers.md
+++ b/azure_devops/5-custom-transformers.md
@@ -38,7 +38,7 @@ You will perform a dry-run for a pipeline in the bootstrapped Azure DevOps proje
 
 3. The command will list all the files written to disk when the command succeeds.
 4. View the converted workflow:
-    - Find `tmp/dry-run` in the file explorer pane in your codespace.
+    - Find `tmp/dry-run/pipelines/lab-testing/pipelines/valet-custom-transformer-example/.github/workflows` in the file explorer pane in your codespace.
     - Click `valet-custom-transformer-example.yml` to open.
 
 The converted workflow that is generated can be seen below:

--- a/azure_devops/5-custom-transformers.md
+++ b/azure_devops/5-custom-transformers.md
@@ -120,7 +120,7 @@ $ gh valet dry-run azure-devops pipeline --pipeline-id 6 --output-dir tmp/dry-ru
 This is the item: {"command"=>"restore", "projects"=>"$(BuildParameters.RESTOREBUILDPROJECTS)"}
 This is the item: {"projects"=>"$(BuildParameters.RESTOREBUILDPROJECTS)", "arguments"=>"--configuration $(BUILDCONFIGURATION)"}
 [2022-09-20 18:39:51] Output file(s):
-[2022-09-20 18:39:51]   tmp/dry-run/lab-test/pipelines/valet-custom-transformer-example.yml
+[2022-09-20 18:39:51]   tmp/dry-run/pipelines/lab-testing/pipelines/valet-custom-transformer-example/.github/workflows/valet-custom-transformer-example.yml
 ```
 
 In the above command you will see two instances of `item` printed to the console. This is because there are two `DotNetCoreCLI@2` steps in the pipeline. Each item listed above represents each `DotNetCoreCLI@2` step in the order that they are defined in the pipeline.

--- a/circle_ci/2-audit.md
+++ b/circle_ci/2-audit.md
@@ -148,40 +148,42 @@ The final section of the audit report provides a manifest of all of the files th
 
 #### valet-labs/circleci-hello-world
 
-- [valet-valet-labs/circleci-hello-world/say-hello-workflow.yml](valet-labs/circleci-hello-world/say-hello-workflow.yml)
-- [valet-labs/circleci-hello-world.config.json](valet-labs/circleci-hello-world.config.json)
-- [valet-labs/circleci-hello-world.source.yml](valet-labs/circleci-hello-world.source.yml)
+- [valet-labs/circleci-hello-world/.github/workflows/say-hello-workflow.yml](valet-labs/circleci-hello-world/.github/workflows/say-hello-workflow.yml)
+- [valet-labs/circleci-hello-world/config.json](valet-labs/circleci-hello-world/config.json)
+- [valet-labs/circleci-hello-world/source.yml](valet-labs/circleci-hello-world/source.yml)
 
 #### valet-labs/circleci-command-example
 
-- [valet-labs/circleci-command-example/my-workflow.yml](valet-labs/circleci-command-example/my-workflow.yml)
-- [.github/actions/greeting/action.yml](.github/actions/greeting/action.yml)
-- [valet-labs/circleci-command-example.config.json](valet-labs/circleci-command-example.config.json)
-- [valet-labs/circleci-command-example.source.yml](valet-labs/circleci-command-example.source.yml)
-
-#### valet-labs/circleci-node-example
-
-- [valet-labs/circleci-node-example/sample.yml](valet-labs/circleci-node-example/sample.yml)
-- [valet-labs/circleci-node-example.config.json](valet-labs/circleci-node-example.config.json)
-- [valet-labs/circleci-node-example.source.yml](valet-labs/circleci-node-example.source.yml)
+- [valet-labs/circleci-command-example/.github/workflows/my-workflow.yml](valet-labs/circleci-command-example/.github/workflows/my-workflow.yml)
+- [valet-labs/circleci-command-example/.github/actions/greeting/action.yml](valet-labs/circleci-command-example/.github/actions/greeting/action.yml)
+- [valet-labs/circleci-command-example/config.json](valet-labs/circleci-command-example/config.json)
+- [valet-labs/circleci-command-example/source.yml](valet-labs/circleci-command-example/source.yml)
 
 #### valet-labs/circleci-python-example
 
-- [valet-labs/circleci-python-example/sample.yml](valet-labs/circleci-python-example/sample.yml)
-- [valet-labs/circleci-python-example.config.json](valet-labs/circleci-python-example.config.json)
-- [valet-labs/circleci-python-example.source.yml](valet-labs/circleci-python-example.source.yml)
+- [valet-labs/circleci-python-example/.github/workflows/sample.yml](valet-labs/circleci-python-example/.github/workflows/sample.yml)
+- [valet-labs/circleci-python-example/config.json](valet-labs/circleci-python-example/config.json)
+- [valet-labs/circleci-python-example/source.yml](valet-labs/circleci-python-example/source.yml)
 
 #### valet-labs/circleci-demo-java-spring
 
-- [valet-labs/circleci-demo-java-spring/workflow.yml](valet-labs/circleci-demo-java-spring/workflow.yml)
-- [valet-labs/circleci-demo-java-spring.config.json](valet-labs/circleci-demo-java-spring.config.json)
-- [valet-labs/circleci-demo-java-spring.source.yml](valet-labs/circleci-demo-java-spring.source.yml)
+- [valet-labs/circleci-demo-java-spring/.github/workflows/workflow.yml](valet-labs/circleci-demo-java-spring/.github/workflows/workflow.yml)
+- [valet-labs/circleci-demo-java-spring/config.json](valet-labs/circleci-demo-java-spring/config.json)
+- [valet-labs/circleci-demo-java-spring/source.yml](valet-labs/circleci-demo-java-spring/source.yml)
 
 #### valet-labs/circleci-demo-ruby-rails
 
-- [valet-labs/circleci-demo-ruby-rails/build_and_test.yml](valet-labs/circleci-demo-ruby-rails/build_and_test.yml)
-- [valet-labs/circleci-demo-ruby-rails.config.json](valet-labs/circleci-demo-ruby-rails.config.json)
-- [valet-labs/circleci-demo-ruby-rails.source.yml](valet-labs/circleci-demo-ruby-rails.source.yml)
+- [valet-labs/circleci-demo-ruby-rails/.github/workflows/build_and_test.yml](valet-labs/circleci-demo-ruby-rails/.github/workflows/build_and_test.yml)
+- [valet-labs/circleci-demo-ruby-rails/config.json](valet-labs/circleci-demo-ruby-rails/config.json)
+- [valet-labs/circleci-demo-ruby-rails/source.yml](valet-labs/circleci-demo-ruby-rails/source.yml)
+
+### Partially successful
+
+#### valet-labs/circleci-node-example
+
+- [valet-labs/circleci-node-example/.github/workflows/sample.yml](valet-labs/circleci-node-example/.github/workflows/sample.yml)
+- [valet-labs/circleci-node-example/config.json](valet-labs/circleci-node-example/config.json)
+- [valet-labs/circleci-node-example/source.yml](valet-labs/circleci-node-example/source.yml)
 ```
 
 Each pipeline will have a variety of files written that include:
@@ -198,19 +200,19 @@ Each pipeline will have a variety of files written that include:
   
     ```csv
     Pipeline,Action,File path
-    valet-labs/circleci-hello-world,actions/checkout@v2,/data/tmp/audit/valet-labs/circleci-hello-world/say-hello-workflow.yml
-    valet-labs/circleci-command-example,./.github/actions/greeting,/data/tmp/audit/valet-labs/circleci-command-example/my-workflow.yml
-    valet-labs/circleci-node-example,actions/checkout@v2,/data/tmp/audit/valet-labs/circleci-node-example/sample.yml
-    valet-labs/circleci-node-example,actions/cache@v2,/data/tmp/audit/valet-labs/circleci-node-example/sample.yml
-    valet-labs/circleci-python-example,actions/checkout@v2,/data/tmp/audit/valet-labs/circleci-python-example/sample.yml
-    valet-labs/circleci-python-example,actions/cache@v2,/data/tmp/audit/valet-labs/circleci-python-example/sample.yml
-    valet-labs/circleci-demo-java-spring,actions/checkout@v2,/data/tmp/audit/valet-labs/circleci-demo-java-spring/workflow.yml
-    valet-labs/circleci-demo-java-spring,actions/cache@v2,/data/tmp/audit/valet-labs/circleci-demo-java-spring/workflow.yml
-    valet-labs/circleci-demo-java-spring,actions/upload-artifact@v2,/data/tmp/audit/valet-labs/circleci-demo-java-spring/workflow.yml
-    valet-labs/circleci-demo-java-spring,actions/download-artifact@v2,/data/tmp/audit/valet-labs/circleci-demo-java-spring/workflow.yml
-    valet-labs/circleci-demo-ruby-rails,ruby/setup-ruby@v1,/data/tmp/audit/valet-labs/circleci-demo-ruby-rails/build_and_test.yml
-    valet-labs/circleci-demo-ruby-rails,actions/checkout@v2,/data/tmp/audit/valet-labs/circleci-demo-ruby-rails/build_and_test.yml
-    valet-labs/circleci-demo-ruby-rails,actions/cache@v2,/data/tmp/audit/valet-labs/circleci-demo-ruby-rails/build_and_test.yml
+    valet-labs/circleci-hello-world,actions/checkout@v2,/data/tmp/valet-labs/circleci-hello-world/.github/workflows/say-hello-workflow.yml
+    valet-labs/circleci-command-example,./.github/actions/greeting,/data/tmp/valet-labs/circleci-command-example/.github/workflows/my-workflow.yml
+    valet-labs/circleci-node-example,actions/checkout@v2,/data/tmp/valet-labs/circleci-node-example/.github/workflows/sample.yml
+    valet-labs/circleci-node-example,actions/cache@v2,/data/tmp/valet-labs/circleci-node-example/.github/workflows/sample.yml
+    valet-labs/circleci-python-example,actions/checkout@v2,/data/tmp/valet-labs/circleci-python-example/.github/workflows/sample.yml
+    valet-labs/circleci-python-example,actions/cache@v2,/data/tmp/valet-labs/circleci-python-example/.github/workflows/sample.yml
+    valet-labs/circleci-demo-java-spring,actions/checkout@v2,/data/tmp/valet-labs/circleci-demo-java-spring/.github/workflows/workflow.yml
+    valet-labs/circleci-demo-java-spring,actions/cache@v2,/data/tmp/valet-labs/circleci-demo-java-spring/.github/workflows/workflow.yml
+    valet-labs/circleci-demo-java-spring,actions/upload-artifact@v2,/data/tmp/valet-labs/circleci-demo-java-spring/.github/workflows/workflow.yml
+    valet-labs/circleci-demo-java-spring,actions/download-artifact@v2,/data/tmp/valet-labs/circleci-demo-java-spring/.github/workflows/workflow.yml
+    valet-labs/circleci-demo-ruby-rails,ruby/setup-ruby@v1,/data/tmp/valet-labs/circleci-demo-ruby-rails/.github/workflows/build_and_test.yml
+    valet-labs/circleci-demo-ruby-rails,actions/checkout@v2,/data/tmp/valet-labs/circleci-demo-ruby-rails/.github/workflows/build_and_test.yml
+    valet-labs/circleci-demo-ruby-rails,actions/cache@v2,/data/tmp/valet-labs/circleci-demo-ruby-rails/.github/workflows/build_and_test.yml
 
     Pipeline,Secret,File path
 

--- a/circle_ci/2-audit.md
+++ b/circle_ci/2-audit.md
@@ -200,19 +200,19 @@ Each pipeline will have a variety of files written that include:
   
     ```csv
     Pipeline,Action,File path
-    valet-labs/circleci-hello-world,actions/checkout@v2,/data/tmp/audit/valet-labs/circleci-hello-world/.github/workflows/say-hello-workflow.yml
-    valet-labs/circleci-command-example,./.github/actions/greeting,/data/tmp/audit/valet-labs/circleci-command-example/.github/workflows/my-workflow.yml
-    valet-labs/circleci-node-example,actions/checkout@v2,/data/tmp/audit/valet-labs/circleci-node-example/.github/workflows/sample.yml
-    valet-labs/circleci-node-example,actions/cache@v2,/data/tmp/audit/valet-labs/circleci-node-example/.github/workflows/sample.yml
-    valet-labs/circleci-python-example,actions/checkout@v2,/data/tmp/audit/valet-labs/circleci-python-example/.github/workflows/sample.yml
-    valet-labs/circleci-python-example,actions/cache@v2,/data/tmp/audit/valet-labs/circleci-python-example/.github/workflows/sample.yml
-    valet-labs/circleci-demo-java-spring,actions/checkout@v2,/data/tmp/audit/valet-labs/circleci-demo-java-spring/.github/workflows/workflow.yml
-    valet-labs/circleci-demo-java-spring,actions/cache@v2,/data/tmp/audit/valet-labs/circleci-demo-java-spring/.github/workflows/workflow.yml
-    valet-labs/circleci-demo-java-spring,actions/upload-artifact@v2,/data/tmp/audit/valet-labs/circleci-demo-java-spring/.github/workflows/workflow.yml
-    valet-labs/circleci-demo-java-spring,actions/download-artifact@v2,/data/tmp/audit/valet-labs/circleci-demo-java-spring/.github/workflows/workflow.yml
-    valet-labs/circleci-demo-ruby-rails,ruby/setup-ruby@v1,/data/tmp/audit/valet-labs/circleci-demo-ruby-rails/.github/workflows/build_and_test.yml
-    valet-labs/circleci-demo-ruby-rails,actions/checkout@v2,/data/tmp/audit/valet-labs/circleci-demo-ruby-rails/.github/workflows/build_and_test.yml
-    valet-labs/circleci-demo-ruby-rails,actions/cache@v2,/data/tmp/audit/valet-labs/circleci-demo-ruby-rails/.github/workflows/build_and_test.yml
+    valet-labs/circleci-hello-world,actions/checkout@v2,tmp/audit/valet-labs/circleci-hello-world/.github/workflows/say-hello-workflow.yml
+    valet-labs/circleci-command-example,./.github/actions/greeting,tmp/audit/valet-labs/circleci-command-example/.github/workflows/my-workflow.yml
+    valet-labs/circleci-node-example,actions/checkout@v2,tmp/audit/valet-labs/circleci-node-example/.github/workflows/sample.yml
+    valet-labs/circleci-node-example,actions/cache@v2,tmp/audit/valet-labs/circleci-node-example/.github/workflows/sample.yml
+    valet-labs/circleci-python-example,actions/checkout@v2,tmp/audit/valet-labs/circleci-python-example/.github/workflows/sample.yml
+    valet-labs/circleci-python-example,actions/cache@v2,tmp/audit/valet-labs/circleci-python-example/.github/workflows/sample.yml
+    valet-labs/circleci-demo-java-spring,actions/checkout@v2,tmp/audit/valet-labs/circleci-demo-java-spring/.github/workflows/workflow.yml
+    valet-labs/circleci-demo-java-spring,actions/cache@v2,tmp/audit/valet-labs/circleci-demo-java-spring/.github/workflows/workflow.yml
+    valet-labs/circleci-demo-java-spring,actions/upload-artifact@v2,tmp/audit/valet-labs/circleci-demo-java-spring/.github/workflows/workflow.yml
+    valet-labs/circleci-demo-java-spring,actions/download-artifact@v2,tmp/audit/valet-labs/circleci-demo-java-spring/.github/workflows/workflow.yml
+    valet-labs/circleci-demo-ruby-rails,ruby/setup-ruby@v1,tmp/audit/valet-labs/circleci-demo-ruby-rails/.github/workflows/build_and_test.yml
+    valet-labs/circleci-demo-ruby-rails,actions/checkout@v2,tmp/audit/valet-labs/circleci-demo-ruby-rails/.github/workflows/build_and_test.yml
+    valet-labs/circleci-demo-ruby-rails,actions/cache@v2,tmp/audit/valet-labs/circleci-demo-ruby-rails/.github/workflows/build_and_test.yml
 
     Pipeline,Secret,File path
 

--- a/circle_ci/2-audit.md
+++ b/circle_ci/2-audit.md
@@ -200,19 +200,19 @@ Each pipeline will have a variety of files written that include:
   
     ```csv
     Pipeline,Action,File path
-    valet-labs/circleci-hello-world,actions/checkout@v2,/data/tmp/valet-labs/circleci-hello-world/.github/workflows/say-hello-workflow.yml
-    valet-labs/circleci-command-example,./.github/actions/greeting,/data/tmp/valet-labs/circleci-command-example/.github/workflows/my-workflow.yml
-    valet-labs/circleci-node-example,actions/checkout@v2,/data/tmp/valet-labs/circleci-node-example/.github/workflows/sample.yml
-    valet-labs/circleci-node-example,actions/cache@v2,/data/tmp/valet-labs/circleci-node-example/.github/workflows/sample.yml
-    valet-labs/circleci-python-example,actions/checkout@v2,/data/tmp/valet-labs/circleci-python-example/.github/workflows/sample.yml
-    valet-labs/circleci-python-example,actions/cache@v2,/data/tmp/valet-labs/circleci-python-example/.github/workflows/sample.yml
-    valet-labs/circleci-demo-java-spring,actions/checkout@v2,/data/tmp/valet-labs/circleci-demo-java-spring/.github/workflows/workflow.yml
-    valet-labs/circleci-demo-java-spring,actions/cache@v2,/data/tmp/valet-labs/circleci-demo-java-spring/.github/workflows/workflow.yml
-    valet-labs/circleci-demo-java-spring,actions/upload-artifact@v2,/data/tmp/valet-labs/circleci-demo-java-spring/.github/workflows/workflow.yml
-    valet-labs/circleci-demo-java-spring,actions/download-artifact@v2,/data/tmp/valet-labs/circleci-demo-java-spring/.github/workflows/workflow.yml
-    valet-labs/circleci-demo-ruby-rails,ruby/setup-ruby@v1,/data/tmp/valet-labs/circleci-demo-ruby-rails/.github/workflows/build_and_test.yml
-    valet-labs/circleci-demo-ruby-rails,actions/checkout@v2,/data/tmp/valet-labs/circleci-demo-ruby-rails/.github/workflows/build_and_test.yml
-    valet-labs/circleci-demo-ruby-rails,actions/cache@v2,/data/tmp/valet-labs/circleci-demo-ruby-rails/.github/workflows/build_and_test.yml
+    valet-labs/circleci-hello-world,actions/checkout@v2,/data/tmp/audit/valet-labs/circleci-hello-world/.github/workflows/say-hello-workflow.yml
+    valet-labs/circleci-command-example,./.github/actions/greeting,/data/tmp/audit/valet-labs/circleci-command-example/.github/workflows/my-workflow.yml
+    valet-labs/circleci-node-example,actions/checkout@v2,/data/tmp/audit/valet-labs/circleci-node-example/.github/workflows/sample.yml
+    valet-labs/circleci-node-example,actions/cache@v2,/data/tmp/audit/valet-labs/circleci-node-example/.github/workflows/sample.yml
+    valet-labs/circleci-python-example,actions/checkout@v2,/data/tmp/audit/valet-labs/circleci-python-example/.github/workflows/sample.yml
+    valet-labs/circleci-python-example,actions/cache@v2,/data/tmp/audit/valet-labs/circleci-python-example/.github/workflows/sample.yml
+    valet-labs/circleci-demo-java-spring,actions/checkout@v2,/data/tmp/audit/valet-labs/circleci-demo-java-spring/.github/workflows/workflow.yml
+    valet-labs/circleci-demo-java-spring,actions/cache@v2,/data/tmp/audit/valet-labs/circleci-demo-java-spring/.github/workflows/workflow.yml
+    valet-labs/circleci-demo-java-spring,actions/upload-artifact@v2,/data/tmp/audit/valet-labs/circleci-demo-java-spring/.github/workflows/workflow.yml
+    valet-labs/circleci-demo-java-spring,actions/download-artifact@v2,/data/tmp/audit/valet-labs/circleci-demo-java-spring/.github/workflows/workflow.yml
+    valet-labs/circleci-demo-ruby-rails,ruby/setup-ruby@v1,/data/tmp/audit/valet-labs/circleci-demo-ruby-rails/.github/workflows/build_and_test.yml
+    valet-labs/circleci-demo-ruby-rails,actions/checkout@v2,/data/tmp/audit/valet-labs/circleci-demo-ruby-rails/.github/workflows/build_and_test.yml
+    valet-labs/circleci-demo-ruby-rails,actions/cache@v2,/data/tmp/audit/valet-labs/circleci-demo-ruby-rails/.github/workflows/build_and_test.yml
 
     Pipeline,Secret,File path
 

--- a/circle_ci/4-dry-run.md
+++ b/circle_ci/4-dry-run.md
@@ -33,11 +33,11 @@ You will be performing a dry run migration against a CircleCI project. Answer th
     $ gh valet dry-run circle-ci --output-dir tmp/dry-run --circle-ci-project circleci-demo-ruby-rails --circle-ci-organization valet-labs
     [2022-09-19 19:46:03] Logs: 'tmp/dry-run/log/valet-20220919-194603.log'     
     [2022-09-19 19:46:05] Output file(s):                                           
-    [2022-09-19 19:46:05]   tmp/dry-run/valet-labs/circleci-demo-ruby-rails/build_and_test.yml
+    [2022-09-19 19:46:05]  tmp/dry-run/valet-labs/circleci-demo-ruby-rails/.github/workflows/build_and_test.yml
     ```
 
 4. View the converted workflow:
-    - Find `tmp/dry-run/valet-labs/circleci-demo-ruby-rails` in the file explorer pane in your codespace.
+    - Find `tmp/dry-run/valet-labs/circleci-demo-ruby-rails/.github/workflows` in the file explorer pane in your codespace.
     - Click `build_and_test.yml` to open.
 
 ## Inspect the output files

--- a/gitlab/2-audit.md
+++ b/gitlab/2-audit.md
@@ -155,23 +155,23 @@ The final section of the audit report provides a manifest of all of the files th
 
 #### valet/included-files-example
 
-- [valet/included-files-example.yml](valet/included-files-example.yml)
-- [valet/included-files-example.config.json](valet/included-files-example.config.json)
-- [valet/included-files-example.source.yml](valet/included-files-example.source.yml)
+- [valet/included-files-example/.github/workflows/included-files-example.yml](valet/included-files-example/.github/workflows/included-files-example.yml)
+- [valet/included-files-example/config.json](valet/included-files-example/config.json)
+- [valet/included-files-example/source.yml](valet/included-files-example/source.yml)
 
 #### valet/terraform-example
 
-- [valet/terraform-example.yml](valet/terraform-example.yml)
-- [valet/terraform-example.config.json](valet/terraform-example.config.json)
-- [valet/terraform-example.source.yml](valet/terraform-example.source.yml)
+- [valet/terraform-example/.github/workflows/terraform-example.yml](valet/terraform-example/.github/workflows/terraform-example.yml)
+- [valet/terraform-example/config.json](valet/terraform-example/config.json)
+- [valet/terraform-example/source.yml](valet/terraform-example/source.yml)
 
 #### valet/child-parent-example
 
-- [valet/child-parent-example.yml](valet/child-parent-example.yml)
-- [.github/workflows/a-.gitlab-ci.yml](.github/workflows/a-.gitlab-ci.yml)
-- [.github/workflows/b-.gitlab-ci.yml](.github/workflows/b-.gitlab-ci.yml)
-- [valet/child-parent-example.config.json](valet/child-parent-example.config.json)
-- [valet/child-parent-example.source.yml](valet/child-parent-example.source.yml)
+- [valet/child-parent-example/.github/workflows/child-parent-example.yml](valet/child-parent-example/.github/workflows/child-parent-example.yml)
+- [valet/child-parent-example/.github/workflows/a-.gitlab-ci.yml](valet/child-parent-example/.github/workflows/a-.gitlab-ci.yml)
+- [valet/child-parent-example/.github/workflows/b-.gitlab-ci.yml](valet/child-parent-example/.github/workflows/b-.gitlab-ci.yml)
+- [valet/child-parent-example/config.json](valet/child-parent-example/config.json)
+- [valet/child-parent-example/source.yml](valet/child-parent-example/source.yml)
 ```
 
 Each pipeline will have a variety of files written that include:
@@ -188,30 +188,30 @@ Each pipeline will have a variety of files written that include:
   
     ```csv
     Pipeline,Action,File path
-    valet/included-files-example,actions/checkout@v2,/data/tmp/audit/valet/included-files-example.yml
-    valet/terraform-example,actions/checkout@v2,/data/tmp/audit/valet/terraform-example.yml
-    valet/child-parent-example,actions/checkout@v2,/data/tmp/audit/valet/child-parent-example.yml
-    valet/child-parent-example,./.github/workflows/a-.gitlab-ci.yml,/data/tmp/audit/valet/child-parent-example.yml
-    valet/child-parent-example,./.github/workflows/b-.gitlab-ci.yml,/data/tmp/audit/valet/child-parent-example.yml
-    valet/include-file-example,actions/checkout@v2,/data/tmp/audit/valet/include-file-example.yml
-    valet/basic-pipeline-example,actions/checkout@v2,/data/tmp/audit/valet/basic-pipeline-example.yml
-    valet/gatsby-example,actions/checkout@v2,/data/tmp/audit/valet/gatsby-example.yml
-    valet/gatsby-example,actions/cache@v2,/data/tmp/audit/valet/gatsby-example.yml
-    valet/gatsby-example,actions/upload-artifact@v2,/data/tmp/audit/valet/gatsby-example.yml
-    valet/gatsby-example,actions/download-artifact@v2,/data/tmp/audit/valet/gatsby-example.yml
-    valet/gatsby-example,JamesIves/github-pages-deploy-action@4.1.5,/data/tmp/audit/valet/gatsby-example.yml
-    valet/android-example,actions/checkout@v2,/data/tmp/audit/valet/android-example.yml
-    valet/android-example,actions/upload-artifact@v2,/data/tmp/audit/valet/android-example.yml
-    valet/android-example,actions/download-artifact@v2,/data/tmp/audit/valet/android-example.yml
-    valet/dotnet-example,actions/checkout@v2,/data/tmp/audit/valet/dotnet-example.yml
-    valet/dotnet-example,actions/upload-artifact@v2,/data/tmp/audit/valet/dotnet-example.yml
-    valet/dotnet-example,actions/download-artifact@v2,/data/tmp/audit/valet/dotnet-example.yml
-    valet/node-example,actions/checkout@v2,/data/tmp/audit/valet/node-example.yml
-    valet/node-example,actions/cache@v2,/data/tmp/audit/valet/node-example.yml
-    valet/rails-example,actions/checkout@v2,/data/tmp/audit/valet/rails-example.yml
+    valet/included-files-example,actions/checkout@v2,/data/tmp/audit/valet/included-files-example/.github/workflows/included-files-example.yml
+    valet/terraform-example,actions/checkout@v2,/data/tmp/audit/valet/terraform-example/.github/workflows/terraform-example.yml
+    valet/child-parent-example,actions/checkout@v2,/data/tmp/audit/valet/child-parent-example/.github/workflows/child-parent-example.yml
+    valet/child-parent-example,./.github/workflows/a-.gitlab-ci.yml,/data/tmp/audit/valet/child-parent-example/.github/workflows/child-parent-example.yml
+    valet/child-parent-example,./.github/workflows/b-.gitlab-ci.yml,/data/tmp/audit/valet/child-parent-example/.github/workflows/child-parent-example.yml
+    valet/include-file-example,actions/checkout@v2,/data/tmp/audit/valet/include-file-example/.github/workflows/include-file-example.yml
+    valet/basic-pipeline-example,actions/checkout@v2,/data/tmp/audit/valet/basic-pipeline-example/.github/workflows/basic-pipeline-example.yml
+    valet/gatsby-example,actions/checkout@v2,/data/tmp/audit/valet/gatsby-example/.github/workflows/gatsby-example.yml
+    valet/gatsby-example,actions/cache@v2,/data/tmp/audit/valet/gatsby-example/.github/workflows/gatsby-example.yml
+    valet/gatsby-example,actions/upload-artifact@v2,/data/tmp/audit/valet/gatsby-example/.github/workflows/gatsby-example.yml
+    valet/gatsby-example,actions/download-artifact@v2,/data/tmp/audit/valet/gatsby-example/.github/workflows/gatsby-example.yml
+    valet/gatsby-example,JamesIves/github-pages-deploy-action@4.1.5,/data/tmp/audit/valet/gatsby-example/.github/workflows/gatsby-example.yml
+    valet/android-example,actions/checkout@v2,/data/tmp/audit/valet/android-example/.github/workflows/android-example.yml
+    valet/android-example,actions/upload-artifact@v2,/data/tmp/audit/valet/android-example/.github/workflows/android-example.yml
+    valet/android-example,actions/download-artifact@v2,/data/tmp/audit/valet/android-example/.github/workflows/android-example.yml
+    valet/dotnet-example,actions/checkout@v2,/data/tmp/audit/valet/dotnet-example/.github/workflows/dotnet-example.yml
+    valet/dotnet-example,actions/upload-artifact@v2,/data/tmp/audit/valet/dotnet-example/.github/workflows/dotnet-example.yml
+    valet/dotnet-example,actions/download-artifact@v2,/data/tmp/audit/valet/dotnet-example/.github/workflows/dotnet-example.yml
+    valet/node-example,actions/checkout@v2,/data/tmp/audit/valet/node-example/.github/workflows/node-example.yml
+    valet/node-example,actions/cache@v2,/data/tmp/audit/valet/node-example/.github/workflows/node-example.yml
+    valet/rails-example,actions/checkout@v2,/data/tmp/audit/valet/rails-example/.github/workflows/rails-example.yml
 
     Pipeline,Secret,File path
-    valet/rails-example,${{ secrets.PASSWORD }},/data/tmp/audit/valet/rails-example.yml
+    valet/rails-example,${{ secrets.PASSWORD }},/data/tmp/audit/valet/rails-example/.github/workflows/rails-example.yml
 
     Pipeline,Runner,File path
     ```

--- a/gitlab/2-audit.md
+++ b/gitlab/2-audit.md
@@ -188,30 +188,30 @@ Each pipeline will have a variety of files written that include:
   
     ```csv
     Pipeline,Action,File path
-    valet/included-files-example,actions/checkout@v2,/data/tmp/audit/valet/included-files-example/.github/workflows/included-files-example.yml
-    valet/terraform-example,actions/checkout@v2,/data/tmp/audit/valet/terraform-example/.github/workflows/terraform-example.yml
-    valet/child-parent-example,actions/checkout@v2,/data/tmp/audit/valet/child-parent-example/.github/workflows/child-parent-example.yml
-    valet/child-parent-example,./.github/workflows/a-.gitlab-ci.yml,/data/tmp/audit/valet/child-parent-example/.github/workflows/child-parent-example.yml
-    valet/child-parent-example,./.github/workflows/b-.gitlab-ci.yml,/data/tmp/audit/valet/child-parent-example/.github/workflows/child-parent-example.yml
-    valet/include-file-example,actions/checkout@v2,/data/tmp/audit/valet/include-file-example/.github/workflows/include-file-example.yml
-    valet/basic-pipeline-example,actions/checkout@v2,/data/tmp/audit/valet/basic-pipeline-example/.github/workflows/basic-pipeline-example.yml
-    valet/gatsby-example,actions/checkout@v2,/data/tmp/audit/valet/gatsby-example/.github/workflows/gatsby-example.yml
-    valet/gatsby-example,actions/cache@v2,/data/tmp/audit/valet/gatsby-example/.github/workflows/gatsby-example.yml
-    valet/gatsby-example,actions/upload-artifact@v2,/data/tmp/audit/valet/gatsby-example/.github/workflows/gatsby-example.yml
-    valet/gatsby-example,actions/download-artifact@v2,/data/tmp/audit/valet/gatsby-example/.github/workflows/gatsby-example.yml
-    valet/gatsby-example,JamesIves/github-pages-deploy-action@4.1.5,/data/tmp/audit/valet/gatsby-example/.github/workflows/gatsby-example.yml
-    valet/android-example,actions/checkout@v2,/data/tmp/audit/valet/android-example/.github/workflows/android-example.yml
-    valet/android-example,actions/upload-artifact@v2,/data/tmp/audit/valet/android-example/.github/workflows/android-example.yml
-    valet/android-example,actions/download-artifact@v2,/data/tmp/audit/valet/android-example/.github/workflows/android-example.yml
+    valet/included-files-example,actions/checkout@v2,tmp/audit/valet/included-files-example/.github/workflows/included-files-example.yml
+    valet/terraform-example,actions/checkout@v2,tmp/audit/valet/terraform-example/.github/workflows/terraform-example.yml
+    valet/child-parent-example,actions/checkout@v2,tmp/audit/valet/child-parent-example/.github/workflows/child-parent-example.yml
+    valet/child-parent-example,./.github/workflows/a-.gitlab-ci.yml,tmp/audit/valet/child-parent-example/.github/workflows/child-parent-example.yml
+    valet/child-parent-example,./.github/workflows/b-.gitlab-ci.yml,tmp/audit/valet/child-parent-example/.github/workflows/child-parent-example.yml
+    valet/include-file-example,actions/checkout@v2,tmp/audit/valet/include-file-example/.github/workflows/include-file-example.yml
+    valet/basic-pipeline-example,actions/checkout@v2,tmp/audit/valet/basic-pipeline-example/.github/workflows/basic-pipeline-example.yml
+    valet/gatsby-example,actions/checkout@v2,tmp/audit/valet/gatsby-example/.github/workflows/gatsby-example.yml
+    valet/gatsby-example,actions/cache@v2,tmp/audit/valet/gatsby-example/.github/workflows/gatsby-example.yml
+    valet/gatsby-example,actions/upload-artifact@v2,tmp/audit/valet/gatsby-example/.github/workflows/gatsby-example.yml
+    valet/gatsby-example,actions/download-artifact@v2,tmp/audit/valet/gatsby-example/.github/workflows/gatsby-example.yml
+    valet/gatsby-example,JamesIves/github-pages-deploy-action@4.1.5,tmp/audit/valet/gatsby-example/.github/workflows/gatsby-example.yml
+    valet/android-example,actions/checkout@v2,tmp/audit/valet/android-example/.github/workflows/android-example.yml
+    valet/android-example,actions/upload-artifact@v2,tmp/audit/valet/android-example/.github/workflows/android-example.yml
+    valet/android-example,actions/download-artifact@v2,tmp/audit/valet/android-example/.github/workflows/android-example.yml
     valet/dotnet-example,actions/checkout@v2,/data/tmp/audit/valet/dotnet-example/.github/workflows/dotnet-example.yml
-    valet/dotnet-example,actions/upload-artifact@v2,/data/tmp/audit/valet/dotnet-example/.github/workflows/dotnet-example.yml
-    valet/dotnet-example,actions/download-artifact@v2,/data/tmp/audit/valet/dotnet-example/.github/workflows/dotnet-example.yml
-    valet/node-example,actions/checkout@v2,/data/tmp/audit/valet/node-example/.github/workflows/node-example.yml
-    valet/node-example,actions/cache@v2,/data/tmp/audit/valet/node-example/.github/workflows/node-example.yml
-    valet/rails-example,actions/checkout@v2,/data/tmp/audit/valet/rails-example/.github/workflows/rails-example.yml
+    valet/dotnet-example,actions/upload-artifact@v2,tmp/audit/valet/dotnet-example/.github/workflows/dotnet-example.yml
+    valet/dotnet-example,actions/download-artifact@v2,tmp/audit/valet/dotnet-example/.github/workflows/dotnet-example.yml
+    valet/node-example,actions/checkout@v2,tmp/audit/valet/node-example/.github/workflows/node-example.yml
+    valet/node-example,actions/cache@v2,tmp/audit/valet/node-example/.github/workflows/node-example.yml
+    valet/rails-example,actions/checkout@v2,tmp/audit/valet/rails-example/.github/workflows/rails-example.yml
 
     Pipeline,Secret,File path
-    valet/rails-example,${{ secrets.PASSWORD }},/data/tmp/audit/valet/rails-example/.github/workflows/rails-example.yml
+    valet/rails-example,${{ secrets.PASSWORD }},tmp/audit/valet/rails-example/.github/workflows/rails-example.yml
 
     Pipeline,Runner,File path
     ```

--- a/gitlab/4-dry-run.md
+++ b/gitlab/4-dry-run.md
@@ -32,10 +32,15 @@ You will be performing a dry run against a pipeline in your preconfigured GitLab
 
 3. The command will list all the files written to disk when the command succeeds.
 
-    ![img](https://user-images.githubusercontent.com/18723510/184173635-aec28d1c-8c61-4dcf-a743-f86cbdc836c5.png)
+    ```console
+    $ gh valet dry-run circle-ci --output-dir tmp/dry-run --circle-ci-project circleci-demo-ruby-rails --circle-ci-organization valet-labs
+    [2022-09-28 19:59:55] Logs: 'tmp/dry-run/log/valet-20220928-195955.log'         
+    [2022-09-28 19:59:56] Output file(s):                                           
+    [2022-09-28 19:59:56]   tmp/dry-run/valet/basic-pipeline-example/.github/workflows/basic-pipeline-example.yml
+    ```
 
 4. View the converted workflow:
-    - Find `tmp/dry-run/valet` in the file explorer pane in your codespace.
+    - Find `tmp/dry-run/valet/basic-pipeline-example/.github/workflows` in the file explorer pane in your codespace.
     - Click `basic-pipeline-example.yml` to open.
 
 ## Inspect the output files

--- a/gitlab/5-custom-transformers.md
+++ b/gitlab/5-custom-transformers.md
@@ -93,10 +93,9 @@ Now, we can perform a `dry-run` command with the `--custom-transformers` CLI opt
 
 ```console
 $ gh valet dry-run gitlab --output-dir tmp --namespace valet --project terraform-example --custom-transformers transformers.rb
-[2022-09-20 17:47:55] Logs: 'tmp/log/valet-20220920-174755.log'                 
-This is the item: $PLAN_JSON                                                    
-[2022-09-20 17:47:56] Output file(s):
-[2022-09-20 17:47:56]   tmp/valet/terraform-example.yml
+[2022-09-28 20:29:41] Logs: 'tmp/log/valet-20220928-202941.log'                 
+[2022-09-28 20:29:43] Output file(s):                                           
+[2022-09-28 20:29:43]   tmp/valet/terraform-example/.github/workflows/terraform-example.yml
 ```
 
 Now that you know the data structure of `item`, you can access the file path programmatically by editing the custom transformer to the following:

--- a/gitlab/5-custom-transformers.md
+++ b/gitlab/5-custom-transformers.md
@@ -93,7 +93,8 @@ Now, we can perform a `dry-run` command with the `--custom-transformers` CLI opt
 
 ```console
 $ gh valet dry-run gitlab --output-dir tmp --namespace valet --project terraform-example --custom-transformers transformers.rb
-[2022-09-28 20:29:41] Logs: 'tmp/log/valet-20220928-202941.log'                 
+[2022-09-28 20:29:41] Logs: 'tmp/log/valet-20220928-202941.log'
+This is the item: $PLAN_JSON  
 [2022-09-28 20:29:43] Output file(s):                                           
 [2022-09-28 20:29:43]   tmp/valet/terraform-example/.github/workflows/terraform-example.yml
 ```

--- a/gitlab/5-custom-transformers.md
+++ b/gitlab/5-custom-transformers.md
@@ -94,8 +94,8 @@ Now, we can perform a `dry-run` command with the `--custom-transformers` CLI opt
 ```console
 $ gh valet dry-run gitlab --output-dir tmp --namespace valet --project terraform-example --custom-transformers transformers.rb
 [2022-09-28 20:29:41] Logs: 'tmp/log/valet-20220928-202941.log'
-This is the item: $PLAN_JSON  
-[2022-09-28 20:29:43] Output file(s):                                           
+This is the item: $PLAN_JSON
+[2022-09-28 20:29:43] Output file(s):
 [2022-09-28 20:29:43]   tmp/valet/terraform-example/.github/workflows/terraform-example.yml
 ```
 

--- a/jenkins/2-audit.md
+++ b/jenkins/2-audit.md
@@ -38,24 +38,24 @@ You will be performing an audit against your preconfigured Jenkins server. Answe
     [2022-08-20 22:08:20] Logs: 'tmp/audit/log/valet-20220916-015817.log'
     [2022-08-20 22:08:20] Auditing 'http://localhost:8080/'
     [2022-08-20 22:08:20] Output file(s):==========================================|
-    [2022-08-20 22:08:20]   tmp/audit/demo_pipeline.yml
-    [2022-08-20 22:08:20]   tmp/audit/demo_pipeline.config.json
-    [2022-08-20 22:08:20]   tmp/audit/demo_pipeline.jenkinsfile
-    [2022-08-20 22:08:20]   tmp/audit/groovy_script.error.txt
-    [2022-08-20 22:08:20]   tmp/audit/groovy_script.config.json
-    [2022-08-20 22:08:20]   tmp/audit/monas_dev_work/monas_freestyle.yml
-    [2022-08-20 22:08:20]   tmp/audit/monas_dev_work/monas_freestyle.config.json
-    [2022-08-20 22:08:20]   tmp/audit/monas_dev_work/monas_pipeline.yml
-    [2022-08-20 22:08:20]   tmp/audit/monas_dev_work/monas_pipeline.config.json
-    [2022-08-20 22:08:20]   tmp/audit/monas_dev_work/monas_pipeline.jenkinsfile
-    [2022-08-20 22:08:20]   tmp/audit/test_freestyle_project.yml
-    [2022-08-20 22:08:20]   tmp/audit/test_freestyle_project.config.json
-    [2022-08-20 22:08:20]   tmp/audit/test_mutlibranch_pipeline.config.json
-    [2022-08-20 22:08:20]   tmp/audit/test_pipeline.yml
-    [2022-08-20 22:08:20]   tmp/audit/test_pipeline.config.json
-    [2022-08-20 22:08:20]   tmp/audit/test_pipeline.jenkinsfile
-    [2022-08-20 22:08:20]   tmp/audit/workflow_usage.csv
-    [2022-08-20 22:08:20]   tmp/audit/audit_summary.md
+    [2022-09-28 20:08:48]   tmp/audit/demo_pipeline/.github/workflows/demo_pipeline.yml
+    [2022-09-28 20:08:48]   tmp/audit/demo_pipeline/config.json
+    [2022-09-28 20:08:48]   tmp/audit/demo_pipeline/jenkinsfile
+    [2022-09-28 20:08:48]   tmp/audit/groovy_script/error.txt
+    [2022-09-28 20:08:48]   tmp/audit/groovy_script/config.json
+    [2022-09-28 20:08:48]   tmp/audit/monas_dev_work/monas_freestyle/.github/workflows/monas_freestyle.yml
+    [2022-09-28 20:08:48]   tmp/audit/monas_dev_work/monas_freestyle/config.json
+    [2022-09-28 20:08:48]   tmp/audit/monas_dev_work/monas_pipeline/.github/workflows/monas_pipeline.yml
+    [2022-09-28 20:08:48]   tmp/audit/monas_dev_work/monas_pipeline/config.json
+    [2022-09-28 20:08:48]   tmp/audit/monas_dev_work/monas_pipeline/jenkinsfile
+    [2022-09-28 20:08:48]   tmp/audit/test_freestyle_project/.github/workflows/test_freestyle_project.yml
+    [2022-09-28 20:08:48]   tmp/audit/test_freestyle_project/config.json
+    [2022-09-28 20:08:48]   tmp/audit/test_mutlibranch_pipeline/config.json
+    [2022-09-28 20:08:48]   tmp/audit/test_pipeline/.github/workflows/test_pipeline.yml
+    [2022-09-28 20:08:48]   tmp/audit/test_pipeline/config.json
+    [2022-09-28 20:08:48]   tmp/audit/test_pipeline/jenkinsfile
+    [2022-09-28 20:08:48]   tmp/audit/workflow_usage.csv
+    [2022-09-28 20:08:48]   tmp/audit/audit_summary.md
     ```
 
 ## Inspect the output files
@@ -191,44 +191,44 @@ The final section of the audit report provides a manifest of all of the files th
 
 #### demo_pipeline
 
-- [demo_pipeline.yml](demo_pipeline.yml)
-- [demo_pipeline.config.json](demo_pipeline.config.json)
-- [demo_pipeline.jenkinsfile](demo_pipeline.jenkinsfile)
+- [demo_pipeline/.github/workflows/demo_pipeline.yml](demo_pipeline/.github/workflows/demo_pipeline.yml)
+- [demo_pipeline/config.json](demo_pipeline/config.json)
+- [demo_pipeline/jenkinsfile](demo_pipeline/jenkinsfile)
 
 #### monas_dev_work/monas_freestyle
 
-- [monas_dev_work/monas_freestyle.yml](monas_dev_work/monas_freestyle.yml)
-- [monas_dev_work/monas_freestyle.config.json](monas_dev_work/monas_freestyle.config.json)
+- [monas_dev_work/monas_freestyle/.github/workflows/monas_freestyle.yml](monas_dev_work/monas_freestyle/.github/workflows/monas_freestyle.yml)
+- [monas_dev_work/monas_freestyle/config.json](monas_dev_work/monas_freestyle/config.json)
 
 #### test_mutlibranch_pipeline
 
-- [test_mutlibranch_pipeline.config.json](test_mutlibranch_pipeline.config.json)
+- [test_mutlibranch_pipeline/config.json](test_mutlibranch_pipeline/config.json)
 
 ### Partially successful
 
 #### monas_dev_work/monas_pipeline
 
-- [monas_dev_work/monas_pipeline.yml](monas_dev_work/monas_pipeline.yml)
-- [monas_dev_work/monas_pipeline.config.json](monas_dev_work/monas_pipeline.config.json)
-- [monas_dev_work/monas_pipeline.jenkinsfile](monas_dev_work/monas_pipeline.jenkinsfile)
+- [monas_dev_work/monas_pipeline/.github/workflows/monas_pipeline.yml](monas_dev_work/monas_pipeline/.github/workflows/monas_pipeline.yml)
+- [monas_dev_work/monas_pipeline/config.json](monas_dev_work/monas_pipeline/config.json)
+- [monas_dev_work/monas_pipeline/jenkinsfile](monas_dev_work/monas_pipeline/jenkinsfile)
 
 #### test_freestyle_project
 
-- [test_freestyle_project.yml](test_freestyle_project.yml)
-- [test_freestyle_project.config.json](test_freestyle_project.config.json)
+- [test_freestyle_project/.github/workflows/test_freestyle_project.yml](test_freestyle_project/.github/workflows/test_freestyle_project.yml)
+- [test_freestyle_project/config.json](test_freestyle_project/config.json)
 
 #### test_pipeline
 
-- [test_pipeline.yml](test_pipeline.yml)
-- [test_pipeline.config.json](test_pipeline.config.json)
-- [test_pipeline.jenkinsfile](test_pipeline.jenkinsfile)
+- [test_pipeline/.github/workflows/test_pipeline.yml](test_pipeline/.github/workflows/test_pipeline.yml)
+- [test_pipeline/config.json](test_pipeline/config.json)
+- [test_pipeline/jenkinsfile](test_pipeline/jenkinsfile)
 
 ### Failed
 
 #### groovy_script
 
-- [groovy_script.error.txt](groovy_script.error.txt)
-- [groovy_script.config.json](groovy_script.config.json)
+- [groovy_script/error.txt](groovy_script/error.txt)
+- [groovy_script/config.json](groovy_script/config.json)
 ```
 
 Each pipeline will have a variety of files written that include:
@@ -245,23 +245,23 @@ Each pipeline will have a variety of files written that include:
   
     ```csv
     Pipeline,Action,File path
-    demo_pipeline,actions/checkout@v2,/data/tmp/audit/demo_pipeline.yml
-    demo_pipeline,actions/upload-artifact@v2,/data/tmp/audit/demo_pipeline.yml
-    demo_pipeline,EnricoMi/publish-unit-test-result-action@v1.7,/data/tmp/audit/demo_pipeline.yml
-    monas_dev_work/monas_freestyle,actions/checkout@v2,/data/tmp/audit/monas_dev_work/monas_freestyle.yml
-    monas_dev_work/monas_pipeline,actions/checkout@v2,/data/tmp/audit/monas_dev_work/monas_pipeline.yml
-    test_freestyle_project,actions/checkout@v2,/data/tmp/audit/test_freestyle_project.yml
-    test_pipeline,actions/checkout@v2,/data/tmp/audit/test_pipeline.yml
-    test_pipeline,EnricoMi/publish-unit-test-result-action@v1.7,/data/tmp/audit/test_pipeline.yml
+    demo_pipeline,actions/checkout@v2,/data/tmp/audit/demo_pipeline/.github/workflows/demo_pipeline.yml
+    demo_pipeline,actions/upload-artifact@v2,/data/tmp/audit/demo_pipeline/.github/workflows/demo_pipeline.yml
+    demo_pipeline,EnricoMi/publish-unit-test-result-action@v1.7,/data/tmp/audit/demo_pipeline/.github/workflows/demo_pipeline.yml
+    monas_dev_work/monas_freestyle,actions/checkout@v2,/data/tmp/audit/monas_dev_work/monas_freestyle/.github/workflows/monas_freestyle.yml
+    monas_dev_work/monas_pipeline,actions/checkout@v2,/data/tmp/audit/monas_dev_work/monas_pipeline/.github/workflows/monas_pipeline.yml
+    test_freestyle_project,actions/checkout@v2,/data/tmp/audit/test_freestyle_project/.github/workflows/test_freestyle_project.yml
+    test_pipeline,actions/checkout@v2,/data/tmp/audit/test_pipeline/.github/workflows/test_pipeline.yml
+    test_pipeline,EnricoMi/publish-unit-test-result-action@v1.7,/data/tmp/audit/test_pipeline/.github/workflows/test_pipeline.yml
 
     Pipeline,Secret,File path
-    monas_dev_work/monas_freestyle,${{ secrets.SECRET_TEST_EXPRESSION_VAR }},/data/tmp/audit/monas_dev_work/monas_freestyle.yml
-    test_freestyle_project,${{ secrets.EXPRESSION_FIRST_VAR }},/data/tmp/audit/test_freestyle_project.yml
+    monas_dev_work/monas_freestyle,${{ secrets.SECRET_TEST_EXPRESSION_VAR }},/data/tmp/audit/monas_dev_work/monas_freestyle/.github/workflows/monas_freestyle.yml
+    test_freestyle_project,${{ secrets.EXPRESSION_FIRST_VAR }},/data/tmp/audit/test_freestyle_project/.github/workflows/test_freestyle_project.yml
 
     Pipeline,Runner,File path
-    demo_pipeline,TeamARunner,/data/tmp/audit/demo_pipeline.yml
-    test_freestyle_project,DemoRunner,/data/tmp/audit/test_freestyle_project.yml
-    test_pipeline,TeamARunner,/data/tmp/audit/test_pipeline.yml
+    demo_pipeline,TeamARunner,/data/tmp/audit/demo_pipeline/.github/workflows/demo_pipeline.yml
+    test_freestyle_project,DemoRunner,/data/tmp/audit/test_freestyle_project/.github/workflows/test_freestyle_project.yml
+    test_pipeline,TeamARunner,/data/tmp/audit/test_pipeline/.github/workflows/test_pipeline.yml
     ```
 
 The contents of this file can be useful in answering questions similar to the following:

--- a/jenkins/2-audit.md
+++ b/jenkins/2-audit.md
@@ -245,23 +245,23 @@ Each pipeline will have a variety of files written that include:
   
     ```csv
     Pipeline,Action,File path
-    demo_pipeline,actions/checkout@v2,/data/tmp/audit/demo_pipeline/.github/workflows/demo_pipeline.yml
-    demo_pipeline,actions/upload-artifact@v2,/data/tmp/audit/demo_pipeline/.github/workflows/demo_pipeline.yml
-    demo_pipeline,EnricoMi/publish-unit-test-result-action@v1.7,/data/tmp/audit/demo_pipeline/.github/workflows/demo_pipeline.yml
-    monas_dev_work/monas_freestyle,actions/checkout@v2,/data/tmp/audit/monas_dev_work/monas_freestyle/.github/workflows/monas_freestyle.yml
-    monas_dev_work/monas_pipeline,actions/checkout@v2,/data/tmp/audit/monas_dev_work/monas_pipeline/.github/workflows/monas_pipeline.yml
-    test_freestyle_project,actions/checkout@v2,/data/tmp/audit/test_freestyle_project/.github/workflows/test_freestyle_project.yml
-    test_pipeline,actions/checkout@v2,/data/tmp/audit/test_pipeline/.github/workflows/test_pipeline.yml
-    test_pipeline,EnricoMi/publish-unit-test-result-action@v1.7,/data/tmp/audit/test_pipeline/.github/workflows/test_pipeline.yml
+    demo_pipeline,actions/checkout@v2,tmp/audit/demo_pipeline/.github/workflows/demo_pipeline.yml
+    demo_pipeline,actions/upload-artifact@v2,tmp/audit/demo_pipeline/.github/workflows/demo_pipeline.yml
+    demo_pipeline,EnricoMi/publish-unit-test-result-action@v1.7,tmp/audit/demo_pipeline/.github/workflows/demo_pipeline.yml
+    monas_dev_work/monas_freestyle,actions/checkout@v2,tmp/audit/monas_dev_work/monas_freestyle/.github/workflows/monas_freestyle.yml
+    monas_dev_work/monas_pipeline,actions/checkout@v2,tmp/audit/monas_dev_work/monas_pipeline/.github/workflows/monas_pipeline.yml
+    test_freestyle_project,actions/checkout@v2,tmp/audit/test_freestyle_project/.github/workflows/test_freestyle_project.yml
+    test_pipeline,actions/checkout@v2,tmp/audit/test_pipeline/.github/workflows/test_pipeline.yml
+    test_pipeline,EnricoMi/publish-unit-test-result-action@v1.7,tmp/audit/test_pipeline/.github/workflows/test_pipeline.yml
 
     Pipeline,Secret,File path
-    monas_dev_work/monas_freestyle,${{ secrets.SECRET_TEST_EXPRESSION_VAR }},/data/tmp/audit/monas_dev_work/monas_freestyle/.github/workflows/monas_freestyle.yml
-    test_freestyle_project,${{ secrets.EXPRESSION_FIRST_VAR }},/data/tmp/audit/test_freestyle_project/.github/workflows/test_freestyle_project.yml
+    monas_dev_work/monas_freestyle,${{ secrets.SECRET_TEST_EXPRESSION_VAR }},tmp/audit/monas_dev_work/monas_freestyle/.github/workflows/monas_freestyle.yml
+    test_freestyle_project,${{ secrets.EXPRESSION_FIRST_VAR }},tmp/audit/test_freestyle_project/.github/workflows/test_freestyle_project.yml
 
     Pipeline,Runner,File path
-    demo_pipeline,TeamARunner,/data/tmp/audit/demo_pipeline/.github/workflows/demo_pipeline.yml
-    test_freestyle_project,DemoRunner,/data/tmp/audit/test_freestyle_project/.github/workflows/test_freestyle_project.yml
-    test_pipeline,TeamARunner,/data/tmp/audit/test_pipeline/.github/workflows/test_pipeline.yml
+    demo_pipeline,TeamARunner,tmp/audit/demo_pipeline/.github/workflows/demo_pipeline.yml
+    test_freestyle_project,DemoRunner,tmp/audit/test_freestyle_project/.github/workflows/test_freestyle_project.yml
+    test_pipeline,TeamARunner,tmp/audit/test_pipeline/.github/workflows/test_pipeline.yml
     ```
 
 The contents of this file can be useful in answering questions similar to the following:

--- a/jenkins/4-dry-run.md
+++ b/jenkins/4-dry-run.md
@@ -34,8 +34,8 @@ You will be performing a dry run against a pipeline in your preconfigured Jenkin
 
     ```console
     $ gh valet dry-run jenkins --source-url http://localhost:8080/job/test_pipeline --output-dir tmp/dry-run
-    [2022-09-28 20:12:00] Logs: 'tmp/dry-run/log/valet-20220928-201200.log'      
-    [2022-09-28 20:12:00] Output file(s):                                
+    [2022-09-28 20:12:00] Logs: 'tmp/dry-run/log/valet-20220928-201200.log'
+    [2022-09-28 20:12:00] Output file(s):
     [2022-09-28 20:12:00]   tmp/dry-run/test_pipeline/.github/workflows/test_pipeline.yml
     ```
 

--- a/jenkins/4-dry-run.md
+++ b/jenkins/4-dry-run.md
@@ -34,8 +34,8 @@ You will be performing a dry run against a pipeline in your preconfigured Jenkin
 
     ```console
     $ gh valet dry-run jenkins --source-url http://localhost:8080/job/test_pipeline --output-dir tmp/dry-run
-    [2022-09-28 20:12:00] Logs: 'tmp/dry-run/log/valet-20220928-201200.log'         
-    [2022-09-28 20:12:00] Output file(s):                                           
+    [2022-09-28 20:12:00] Logs: 'tmp/dry-run/log/valet-20220928-201200.log'      
+    [2022-09-28 20:12:00] Output file(s):                                
     [2022-09-28 20:12:00]   tmp/dry-run/test_pipeline/.github/workflows/test_pipeline.yml
     ```
 

--- a/jenkins/4-dry-run.md
+++ b/jenkins/4-dry-run.md
@@ -34,13 +34,13 @@ You will be performing a dry run against a pipeline in your preconfigured Jenkin
 
     ```console
     $ gh valet dry-run jenkins --source-url http://localhost:8080/job/test_pipeline --output-dir tmp/dry-run
-    [2022-08-20 22:08:20] Logs: 'tmp/dry-run/log/valet-20220916-022338.log'
-    [2022-08-20 22:08:20] Output file(s):
-    [2022-08-20 22:08:20]   tmp/dry-run/test_pipeline.yml
+    [2022-09-28 20:12:00] Logs: 'tmp/dry-run/log/valet-20220928-201200.log'         
+    [2022-09-28 20:12:00] Output file(s):                                           
+    [2022-09-28 20:12:00]   tmp/dry-run/test_pipeline/.github/workflows/test_pipeline.yml
     ```
 
 4. View the converted workflow:
-    - Find `tmp/dry-run` in the file explorer pane in your codespace.
+    - Find `tmp/dry-run/test_pipeline/.github/workflows` in the file explorer pane in your codespace.
     - Click `test_pipeline.yml` to open
 
 ## Inspect the output files

--- a/jenkins/5-custom-transformers.md
+++ b/jenkins/5-custom-transformers.md
@@ -165,7 +165,7 @@ $ gh valet dry-run jenkins --source-url http://localhost:8080/job/test_pipeline 
 [2022-08-20 22:08:20] Logs: 'tmp/dry-run/log/valet-20220916-022628.log'
 This is the item: {"name"=>"junit", "arguments"=>[{"key"=>"testResults", "value"=>{"isLiteral"=>true, "value"=>"**/target/*.xml"}}]}
 [2022-08-20 22:08:20] Output file(s):
-[2022-08-20 22:08:20]   tmp/dry-run/test_pipeline.yml
+[2022-08-20 22:08:20]   tmp/dry-run/test_pipeline/.github/workflows/test_pipeline.yml
 ```
 
 Now that you know the data structure of `item`, you can access the file path programmatically by editing the custom transformer to the following:

--- a/travis/2-audit.md
+++ b/travis/2-audit.md
@@ -323,18 +323,18 @@ Each pipeline will have a variety of files written that include:
   
     ```csv
     Pipeline,Action,File path
-    valet-labs/travisci-php-example,actions/checkout@v2,/data/tmp/audit/valet-labs/travisci-php-example/.github/workflows/travisci-php-example.yml
-    valet-labs/travisci-php-example,shivammathur/setup-php@v2,/data/tmp/audit/valet-labs/travisci-php-example/.github/workflows/travisci-php-example.yml
-    valet-labs/travisci-php-example,rectalogic/notify-irc@v1,/data/tmp/audit/valet-labs/travisci-php-example/.github/workflows/travisci-php-example.yml
-    valet-labs/travisci-nodejs-example,actions/checkout@v2,/data/tmp/audit/valet-labs/travisci-nodejs-example/.github/workflows/travisci-nodejs-example.yml
-    valet-labs/travisci-ruby-example,actions/checkout@v2,/data/tmp/audit/valet-labs/travisci-ruby-example/.github/workflows/travisci-ruby-example.yml
-    valet-labs/travisci-ruby-example,ruby/setup-ruby@v1,/data/tmp/audit/valet-labs/travisci-ruby-example/.github/workflows/travisci-ruby-example.yml
-    valet-labs/travisci-python-example,actions/checkout@v2,/data/tmp/audit/valet-labs/travisci-python-example/.github/workflows/travisci-python-example.yml
-    valet-labs/travisci-deploy-example,actions/checkout@v2,/data/tmp/audit/valet-labs/travisci-deploy-example/.github/workflows/travisci-deploy-example.yml
-    valet-labs/travisci-deploy-example,desiderati/github-action-pushover@v1,/data/tmp/audit/valet-labs/travisci-deploy-example/.github/workflows/travisci-deploy-example.yml
+    valet-labs/travisci-php-example,actions/checkout@v2,tmp/audit/valet-labs/travisci-php-example/.github/workflows/travisci-php-example.yml
+    valet-labs/travisci-php-example,shivammathur/setup-php@v2,tmp/audit/valet-labs/travisci-php-example/.github/workflows/travisci-php-example.yml
+    valet-labs/travisci-php-example,rectalogic/notify-irc@v1,tmp/audit/valet-labs/travisci-php-example/.github/workflows/travisci-php-example.yml
+    valet-labs/travisci-nodejs-example,actions/checkout@v2,tmp/audit/valet-labs/travisci-nodejs-example/.github/workflows/travisci-nodejs-example.yml
+    valet-labs/travisci-ruby-example,actions/checkout@v2,tmp/audit/valet-labs/travisci-ruby-example/.github/workflows/travisci-ruby-example.yml
+    valet-labs/travisci-ruby-example,ruby/setup-ruby@v1,tmp/audit/valet-labs/travisci-ruby-example/.github/workflows/travisci-ruby-example.yml
+    valet-labs/travisci-python-example,actions/checkout@v2,tmp/audit/valet-labs/travisci-python-example/.github/workflows/travisci-python-example.yml
+    valet-labs/travisci-deploy-example,actions/checkout@v2,tmp/audit/valet-labs/travisci-deploy-example/.github/workflows/travisci-deploy-example.yml
+    valet-labs/travisci-deploy-example,desiderati/github-action-pushover@v1,tmp/audit/valet-labs/travisci-deploy-example/.github/workflows/travisci-deploy-example.yml
 
     Pipeline,Secret,File path
-    valet-labs/travisci-deploy-example,${{ secrets.PUSHOVER_USER_KEY }},/data/tmp/audit/valet-labs/travisci-deploy-example/.github/workflows/travisci-deploy-example.yml
+    valet-labs/travisci-deploy-example,${{ secrets.PUSHOVER_USER_KEY }},tmp/audit/valet-labs/travisci-deploy-example/.github/workflows/travisci-deploy-example.yml
 
     Pipeline,Runner,File path
     ```

--- a/travis/2-audit.md
+++ b/travis/2-audit.md
@@ -162,33 +162,33 @@ Secrets: **1**
 
 #### valet-labs/travisci-php-example
 
-- [valet-labs/travisci-php-example.yml](valet-labs/travisci-php-example.yml)
-- [valet-labs/travisci-php-example.config.json](valet-labs/travisci-php-example.config.json)
-- [valet-labs/travisci-php-example.source.yml](valet-labs/travisci-php-example.source.yml)
+- [valet-labs/travisci-php-example/.github/workflows/travisci-php-example.yml](valet-labs/travisci-php-example/.github/workflows/travisci-php-example.yml)
+- [valet-labs/travisci-php-example/config.json](valet-labs/travisci-php-example/config.json)
+- [valet-labs/travisci-php-example/source.yml](valet-labs/travisci-php-example/source.yml)
 
 #### valet-labs/travisci-nodejs-example
 
-- [valet-labs/travisci-nodejs-example.yml](valet-labs/travisci-nodejs-example.yml)
-- [valet-labs/travisci-nodejs-example.config.json](valet-labs/travisci-nodejs-example.config.json)
-- [valet-labs/travisci-nodejs-example.source.yml](valet-labs/travisci-nodejs-example.source.yml)
+- [valet-labs/travisci-nodejs-example/.github/workflows/travisci-nodejs-example.yml](valet-labs/travisci-nodejs-example/.github/workflows/travisci-nodejs-example.yml)
+- [valet-labs/travisci-nodejs-example/config.json](valet-labs/travisci-nodejs-example/config.json)
+- [valet-labs/travisci-nodejs-example/source.yml](valet-labs/travisci-nodejs-example/source.yml)
 
 #### valet-labs/travisci-ruby-example
 
-- [valet-labs/travisci-ruby-example.yml](valet-labs/travisci-ruby-example.yml)
-- [valet-labs/travisci-ruby-example.config.json](valet-labs/travisci-ruby-example.config.json)
-- [valet-labs/travisci-ruby-example.source.yml](valet-labs/travisci-ruby-example.source.yml)
+- [valet-labs/travisci-ruby-example/.github/workflows/travisci-ruby-example.yml](valet-labs/travisci-ruby-example/.github/workflows/travisci-ruby-example.yml)
+- [valet-labs/travisci-ruby-example/config.json](valet-labs/travisci-ruby-example/config.json)
+- [valet-labs/travisci-ruby-example/source.yml](valet-labs/travisci-ruby-example/source.yml)
 
 #### valet-labs/travisci-python-example
 
-- [valet-labs/travisci-python-example.yml](valet-labs/travisci-python-example.yml)
-- [valet-labs/travisci-python-example.config.json](valet-labs/travisci-python-example.config.json)
-- [valet-labs/travisci-python-example.source.yml](valet-labs/travisci-python-example.source.yml)
+- [valet-labs/travisci-python-example/.github/workflows/travisci-python-example.yml](valet-labs/travisci-python-example/.github/workflows/travisci-python-example.yml)
+- [valet-labs/travisci-python-example/config.json](valet-labs/travisci-python-example/config.json)
+- [valet-labs/travisci-python-example/source.yml](valet-labs/travisci-python-example/source.yml)
 
 #### valet-labs/travisci-deploy-example
 
-- [valet-labs/travisci-deploy-example.yml](valet-labs/travisci-deploy-example.yml)
-- [valet-labs/travisci-deploy-example.config.json](valet-labs/travisci-deploy-example.config.json)
-- [valet-labs/travisci-deploy-example.source.yml](valet-labs/travisci-deploy-example.source.yml)
+- [valet-labs/travisci-deploy-example/.github/workflows/travisci-deploy-example.yml](valet-labs/travisci-deploy-example/.github/workflows/travisci-deploy-example.yml)
+- [valet-labs/travisci-deploy-example/config.json](valet-labs/travisci-deploy-example/config.json)
+- [valet-labs/travisci-deploy-example/source.yml](valet-labs/travisci-deploy-example/source.yml)
 ```
 
 Here are some key terms that can appear in the “Pipelines” section:
@@ -280,33 +280,33 @@ The final section of the audit report provides a manifest of all of the files th
 
 #### valet-labs/travisci-php-example
 
-- [valet-labs/travisci-php-example.yml](valet-labs/travisci-php-example.yml)
-- [valet-labs/travisci-php-example.config.json](valet-labs/travisci-php-example.config.json)
-- [valet-labs/travisci-php-example.source.yml](valet-labs/travisci-php-example.source.yml)
+- [valet-labs/travisci-php-example/.github/workflows/travisci-php-example.yml](valet-labs/travisci-php-example/.github/workflows/travisci-php-example.yml)
+- [valet-labs/travisci-php-example/config.json](valet-labs/travisci-php-example/config.json)
+- [valet-labs/travisci-php-example/source.yml](valet-labs/travisci-php-example/source.yml)
 
 #### valet-labs/travisci-nodejs-example
 
-- [valet-labs/travisci-nodejs-example.yml](valet-labs/travisci-nodejs-example.yml)
-- [valet-labs/travisci-nodejs-example.config.json](valet-labs/travisci-nodejs-example.config.json)
-- [valet-labs/travisci-nodejs-example.source.yml](valet-labs/travisci-nodejs-example.source.yml)
+- [valet-labs/travisci-nodejs-example/.github/workflows/travisci-nodejs-example.yml](valet-labs/travisci-nodejs-example/.github/workflows/travisci-nodejs-example.yml)
+- [valet-labs/travisci-nodejs-example/config.json](valet-labs/travisci-nodejs-example/config.json)
+- [valet-labs/travisci-nodejs-example/source.yml](valet-labs/travisci-nodejs-example/source.yml)
 
 #### valet-labs/travisci-ruby-example
 
-- [valet-labs/travisci-ruby-example.yml](valet-labs/travisci-ruby-example.yml)
-- [valet-labs/travisci-ruby-example.config.json](valet-labs/travisci-ruby-example.config.json)
-- [valet-labs/travisci-ruby-example.source.yml](valet-labs/travisci-ruby-example.source.yml)
+- [valet-labs/travisci-ruby-example/.github/workflows/travisci-ruby-example.yml](valet-labs/travisci-ruby-example/.github/workflows/travisci-ruby-example.yml)
+- [valet-labs/travisci-ruby-example/config.json](valet-labs/travisci-ruby-example/config.json)
+- [valet-labs/travisci-ruby-example/source.yml](valet-labs/travisci-ruby-example/source.yml)
 
 #### valet-labs/travisci-python-example
 
-- [valet-labs/travisci-python-example.yml](valet-labs/travisci-python-example.yml)
-- [valet-labs/travisci-python-example.config.json](valet-labs/travisci-python-example.config.json)
-- [valet-labs/travisci-python-example.source.yml](valet-labs/travisci-python-example.source.yml)
+- [valet-labs/travisci-python-example/.github/workflows/travisci-python-example.yml](valet-labs/travisci-python-example/.github/workflows/travisci-python-example.yml)
+- [valet-labs/travisci-python-example/config.json](valet-labs/travisci-python-example/config.json)
+- [valet-labs/travisci-python-example/source.yml](valet-labs/travisci-python-example/source.yml)
 
 #### valet-labs/travisci-deploy-example
 
-- [valet-labs/travisci-deploy-example.yml](valet-labs/travisci-deploy-example.yml)
-- [valet-labs/travisci-deploy-example.config.json](valet-labs/travisci-deploy-example.config.json)
-- [valet-labs/travisci-deploy-example.source.yml](valet-labs/travisci-deploy-example.source.yml)
+- [valet-labs/travisci-deploy-example/.github/workflows/travisci-deploy-example.yml](valet-labs/travisci-deploy-example/.github/workflows/travisci-deploy-example.yml)
+- [valet-labs/travisci-deploy-example/config.json](valet-labs/travisci-deploy-example/config.json)
+- [valet-labs/travisci-deploy-example/source.yml](valet-labs/travisci-deploy-example/source.yml)
 ```
 
 Each pipeline will have a variety of files written that include:
@@ -323,18 +323,18 @@ Each pipeline will have a variety of files written that include:
   
     ```csv
     Pipeline,Action,File path
-    valet-labs/travisci-php-example,actions/checkout@v2,/data/tmp/audit/valet-labs/travisci-php-example.yml
-    valet-labs/travisci-php-example,shivammathur/setup-php@v2,/data/tmp/audit/valet-labs/travisci-php-example.yml
-    valet-labs/travisci-php-example,rectalogic/notify-irc@v1,/data/tmp/audit/valet-labs/travisci-php-example.yml
-    valet-labs/travisci-nodejs-example,actions/checkout@v2,/data/tmp/audit/valet-labs/travisci-nodejs-example.yml
-    valet-labs/travisci-ruby-example,actions/checkout@v2,/data/tmp/audit/valet-labs/travisci-ruby-example.yml
-    valet-labs/travisci-ruby-example,ruby/setup-ruby@v1,/data/tmp/audit/valet-labs/travisci-ruby-example.yml
-    valet-labs/travisci-python-example,actions/checkout@v2,/data/tmp/audit/valet-labs/travisci-python-example.yml
-    valet-labs/travisci-deploy-example,actions/checkout@v2,/data/tmp/audit/valet-labs/travisci-deploy-example.yml
-    valet-labs/travisci-deploy-example,desiderati/github-action-pushover@v1,/data/tmp/audit/valet-labs/travisci-deploy-example.yml
+    valet-labs/travisci-php-example,actions/checkout@v2,/data/tmp/audit/valet-labs/travisci-php-example/.github/workflows/travisci-php-example.yml
+    valet-labs/travisci-php-example,shivammathur/setup-php@v2,/data/tmp/audit/valet-labs/travisci-php-example/.github/workflows/travisci-php-example.yml
+    valet-labs/travisci-php-example,rectalogic/notify-irc@v1,/data/tmp/audit/valet-labs/travisci-php-example/.github/workflows/travisci-php-example.yml
+    valet-labs/travisci-nodejs-example,actions/checkout@v2,/data/tmp/audit/valet-labs/travisci-nodejs-example/.github/workflows/travisci-nodejs-example.yml
+    valet-labs/travisci-ruby-example,actions/checkout@v2,/data/tmp/audit/valet-labs/travisci-ruby-example/.github/workflows/travisci-ruby-example.yml
+    valet-labs/travisci-ruby-example,ruby/setup-ruby@v1,/data/tmp/audit/valet-labs/travisci-ruby-example/.github/workflows/travisci-ruby-example.yml
+    valet-labs/travisci-python-example,actions/checkout@v2,/data/tmp/audit/valet-labs/travisci-python-example/.github/workflows/travisci-python-example.yml
+    valet-labs/travisci-deploy-example,actions/checkout@v2,/data/tmp/audit/valet-labs/travisci-deploy-example/.github/workflows/travisci-deploy-example.yml
+    valet-labs/travisci-deploy-example,desiderati/github-action-pushover@v1,/data/tmp/audit/valet-labs/travisci-deploy-example/.github/workflows/travisci-deploy-example.yml
 
     Pipeline,Secret,File path
-    valet-labs/travisci-deploy-example,${{ secrets.PUSHOVER_USER_KEY }},/data/tmp/audit/valet-labs/travisci-deploy-example.yml
+    valet-labs/travisci-deploy-example,${{ secrets.PUSHOVER_USER_KEY }},/data/tmp/audit/valet-labs/travisci-deploy-example/.github/workflows/travisci-deploy-example.yml
 
     Pipeline,Runner,File path
     ```

--- a/travis/4-dry-run.md
+++ b/travis/4-dry-run.md
@@ -33,11 +33,11 @@ You will be performing a dry-run against a TravisCI project. Answer the followin
     $ gh valet dry-run travis-ci --travis-ci-repository "travisci-ruby-example" --output-dir tmp/dry-run
     [2022-09-19 19:46:03] Logs: 'tmp/dry-run/log/valet-20220919-194603.log'     
     [2022-09-19 19:46:05] Output file(s):                                           
-    [2022-09-19 19:46:05]   tmp/dry-run/valet-labs/travisci-ruby-example.yml
+    [2022-09-19 19:46:05]   tmp/dry-run/valet-labs/travisci-ruby-example/.github/workflows/travisci-ruby-example.yml
     ```
 
 4. View the converted workflow:
-    - Find `tmp/dry-run/valet-labs` in the file explorer pane in your codespace.
+    - Find `tmp/dry-run/valet-labs/travisci-ruby-example/.github/workflows` in the file explorer pane in your codespace.
     - Click `travisci-ruby-example.yml` to open.
 
 ## Inspect the output files


### PR DESCRIPTION
## What is Changing?
Updates the `dry-run` and `audit` file paths that changed due to  github/valet#4623

Closes: github/valet#4685
